### PR TITLE
Fix buildgen for targets with defaulted names

### DIFF
--- a/src/python/fsqio/pants/buildgen/core/build_file_manipulator.py
+++ b/src/python/fsqio/pants/buildgen/core/build_file_manipulator.py
@@ -143,9 +143,7 @@ class BuildFileManipulator(object):
                         .format(build_file=build_file,
                                 target_type=call.func.id,
                                 name_value=keyword.value))
-      raise BuildTargetParseError('Could not find name parameter to target call'
-                                  'with target type {target_type}'
-                                  .format(target_type=call.func.id))
+      return os.path.basename(build_file.spec_path)
 
     calls_by_name = dict((name_from_call(call), call) for call in target_calls)
     if name not in calls_by_name:


### PR DESCRIPTION
Pant's BUILD name field is now optional and defaults to the basename of the directory it's in; this patches buildgen to support that.

Not sure if there's tests somewhere for this.