### PR TITLE
Update opensource-pants-env.sh

### DIFF
--- a/build-support/fsqio/upkeep/scripts/opensource-pants-env.sh
+++ b/build-support/fsqio/upkeep/scripts/opensource-pants-env.sh
@@ -42,7 +42,7 @@ function bootstrap_venv {
       mkdir -p "${PANTS_BOOTSTRAP}" && \
       staging_dir=$(tempdir "${PANTS_BOOTSTRAP}") && \
       cd ${staging_dir} && \
-      curl -O https://pypi.python.org/packages/source/v/virtualenv/${VENV_TARBALL} && \
+      curl -LO https://pypi.python.org/packages/source/v/virtualenv/${VENV_TARBALL} && \
       tar -xzf ${VENV_TARBALL} && \
       ln -s "${staging_dir}/${VENV_PACKAGE}" "${staging_dir}/latest" && \
       mv "${staging_dir}/latest" "${PANTS_BOOTSTRAP}/${VENV_PACKAGE}"


### PR DESCRIPTION
The Python CDN has moved from "pypi.python.org" to "files.pythonhosted.org".  Curl must be told to follow those redirects in order to successfully download the virtualenv.  Otherwise, it downloads the Move response to a file which isn't a tarball, and prevents twofishes (and possibly other elements of fsqio) from serving and parsing.