### PR TITLE
Add scripts to modernize to Python 3

### DIFF
--- a/scripts/fsqio/python3-port-utils/pants/modernize_classes.py
+++ b/scripts/fsqio/python3-port-utils/pants/modernize_classes.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+from pathlib import Path
+
+from typing import Sequence, Set
+
+SUPER_REGEX = r"super\([a-zA-Z]+, [a-z]+\)"
+OBJECT_REGEX = r"class (?P<className>[a-zA-Z]*)\(object\):"
+
+
+def main() -> None:
+  folders = create_parser().parse_args().folders
+  for fp in get_relevant_files(folders):
+    simplify(file_path=fp, regex=SUPER_REGEX, replacement="super()")
+    simplify(file_path=fp, regex=OBJECT_REGEX, replacement=r"class \g<className>:")
+
+
+def create_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(
+    description='Remove `from builtins import x`, and possibly the BUILD entry for `future`.')
+  parser.add_argument('folders', nargs='*')
+  return parser
+
+
+def get_relevant_files(folders: Sequence[str]) -> Set[Path]:
+  return {
+    fp
+    for folder in folders
+    for fp in Path(folder).rglob("*.py")
+    if any(
+      re.search(SUPER_REGEX, line) or re.search(OBJECT_REGEX, line)
+      for line in fp.read_text().splitlines()
+    )
+  }
+
+
+def simplify(*, file_path: Path, regex: str, replacement: str) -> None:
+  lines = file_path.read_text().splitlines()
+  indexes = [i for i, line in enumerate(lines) if re.search(regex, line)]
+  for index in indexes:
+    new_line = re.sub(regex, replacement, lines[index])
+    lines[index] = new_line
+  file_path.write_text("\n".join(lines) + "\n")
+
+
+if __name__ == '__main__':
+  try:
+    main()
+  except KeyboardInterrupt:
+    pass

--- a/scripts/fsqio/python3-port-utils/pants/remove_builtins.py
+++ b/scripts/fsqio/python3-port-utils/pants/remove_builtins.py
@@ -1,185 +1,66 @@
 #!/usr/bin/env python3
 
 import argparse
-import shutil
 import subprocess
+from pathlib import Path
 from textwrap import dedent
 
-from typing import List, NamedTuple
+from typing import List, Sequence, Set
 
 
 def main() -> None:
-  check_ripgrep_installed()
-  parser = create_parser()
-  args = parser.parse_args()
-  if not args.file_names:
-    target_root = determine_target_root(args.folder, args.contrib, args.test)
-    check_what_needs_changes(target_root, args.root_only)
-    return
-  for file_name in args.file_names:
-    paths = determine_paths(args, file_name)
-    remove_builtins(paths.file_path)
-    if safe_to_remove_future_from_build(paths.file_path):
-      update_build_dependencies(paths.target_root, paths.pants_target_name, file_name)
+  folders = create_parser().parse_args().folders
+  for fp in get_files_with_import(folders):
+    remove_builtins(file_path=fp)
+    if safe_to_remove_future_from_build(file_path=fp):
+      target_name = determine_pants_target_name(file_path=fp)
+      update_build_dependencies(file_path=fp, pants_target_name=target_name)
 
-
-# --------------------------------------------------
-# Command line utils
-# -------------------------------------------------
-
-def get_stdout(command: List[str]) -> str:
-  return subprocess.run(
-    command,
-    stdout=subprocess.PIPE,
-    encoding='utf-8') \
-    .stdout.strip()
-
-
-def get_stderr(command: List[str]) -> str:
-  return subprocess.run(
-    command,
-    stderr=subprocess.PIPE,
-    encoding='utf-8') \
-    .stderr.strip()
-
-
-def check_ripgrep_installed() -> None:
-  if not shutil.which('rg'):
-    raise SystemExit(
-      'Ripgrep must be installed. See https://github.com/BurntSushi/ripgrep#installation.')
-
-
-# --------------------------------------------------
-# Setup
-# -------------------------------------------------
 
 def create_parser() -> argparse.ArgumentParser:
-  parser = argparse.ArgumentParser(description='Add open() backport to targets.')
-  parser.add_argument('folder', help='Target folder name, e.g. backend/jvm')
-  parser.add_argument(
-    'file_names',
-    nargs='*',
-    default=[],
-    help='Specific .py file(s). Ignore this arg to see changes necessary in folder.'
-  )
-  parser.add_argument('-t', '--test', action='store_true', help='Operate on test targets.')
-  parser.add_argument('-p', '--preview', action='store_true', help='Do not write changes.')
-  parser.add_argument('-r', '--root-only', action='store_true',
-                      help='Do not recursively search subfolders.')
-  parser.add_argument('-c', '--contrib', action='store_true',
-                      help='Operate on targets in contrib/.')
+  parser = argparse.ArgumentParser(
+    description='Remove `from builtins import x`, and possibly the BUILD entry for `future`.')
+  parser.add_argument('folders', nargs='*')
   return parser
 
 
-class Paths(NamedTuple):
-  target_root: str
-  file_path: str
-  pants_target_name: str
-  pants_target_path: str
-  pants_test_path: str
+def get_files_with_import(folders: Sequence[str]) -> Set[Path]:
+  return {
+    fp
+    for folder in folders
+    for fp in Path(folder).rglob("*.py")
+    if not fp.name.endswith("__init__.py")
+    and "from builtins import" in fp.read_text()
+  }
 
 
-SRC_BASE_ROOT = 'src/python/pants'
-TEST_BASE_ROOT = 'tests/python/pants_test'
-
-
-def determine_paths(args, file_name: str) -> Paths:
-  target_root = determine_target_root(args.folder, args.contrib, args.test)
-  test_root = determine_target_root(args.folder, args.contrib, is_test=True)
-  pants_target_name = determine_pants_target_name(target_root, file_name)
-  file_path = f'{target_root}/{file_name}'
-  pants_target_path = f'{target_root}:{pants_target_name}'
-  pants_test_path = f'{test_root}:{pants_target_name}'
-  return Paths(
-    target_root=target_root,
-    file_path=file_path,
-    pants_target_name=pants_target_name,
-    pants_target_path=pants_target_path,
-    pants_test_path=pants_test_path
-  )
-
-
-def determine_target_root(folder: str, is_contrib: bool, is_test: bool) -> str:
-  if is_contrib:
-    target_folder_root = folder.split('/')[0]
-    base_root = (f'contrib/{target_folder_root}/{TEST_BASE_ROOT}/contrib'
-                 if is_test
-                 else f'contrib/{target_folder_root}/{SRC_BASE_ROOT}/contrib')
-  else:
-    base_root = TEST_BASE_ROOT if is_test else SRC_BASE_ROOT
-  return f'{base_root}/{folder}' if folder else base_root
-
-
-def determine_pants_target_name(target_root: str, file_name: str) -> str:
-  file_map = get_stdout([
+def determine_pants_target_name(file_path: Path) -> str:
+  file_map = subprocess.run([
     './pants',
     'filemap',
-    f'{target_root}:'
-  ]).split('\n')
-  target_entry = next((line for line in file_map if file_name in line), None)
+    f'{file_path.parent}:'
+  ], stdout=subprocess.PIPE, encoding="utf-8").stdout.strip().split('\n')
+  target_entry = next((line for line in file_map if file_path.name in line), None)
   if target_entry is None:
     raise SystemExit(dedent(f"""\n
-        ERROR: File name '{file_name}' invalid. Not found anywhere in {target_root}/BUILD."""))
+        ERROR: File '{file_path}' invalid. Not found anywhere in {file_path.parent}/BUILD."""))
   pants_target_path = target_entry.split(' ')[1]
   pants_target_name = pants_target_path.split(':')[1]
   return pants_target_name
 
 
-# --------------------------------------------------
-# Grep
-# -------------------------------------------------
-
-REGEX = r'from builtins import'
-
-
-def check_what_needs_changes(folder_root: str, root_only: bool) -> None:
-  target = f"{folder_root}/*.py" if root_only else f"{folder_root}/**/*.py"
-  grep_output = get_stdout(['rg', '-l', REGEX, '-g', target]).split('\n')
-  remove_unnecessary = [p for p in grep_output if p]
-  if not remove_unnecessary:
-    print('No builtins imports 🐍 🎉')
-    return
-  pretty_printed = format_for_cli(remove_unnecessary, root_only)
-  print(pretty_printed)
-
-
-def format_for_cli(file_paths: List[str], root_only: bool) -> str:
-  def drop_prefix(line: str) -> str:
-    return (line.split(f'{TEST_BASE_ROOT}/')[1]
-            if TEST_BASE_ROOT in line
-            else line.split(f'{SRC_BASE_ROOT}/')[1])
-
-  remove_path_prefix = [drop_prefix(line) for line in file_paths]
-
-  if 'contrib' in file_paths[0]:
-    remove_path_prefix = [line.split('contrib/')[1] for line in remove_path_prefix]
-  formatted_for_cli = ([f"{line.split('/')[-1]}" for line in remove_path_prefix]
-                       if root_only
-                       else [f"{'/'.join(line.split('/')[:-1])} {line.split('/')[-1]}" for line in
-                             remove_path_prefix])
-  delimiter = '\n' if not root_only else ' '
-  return delimiter.join(sorted(formatted_for_cli))
-
-
-# --------------------------------------------------
-# Remove import
-# -------------------------------------------------
-
-def remove_builtins(file_path: str) -> None:
-  with open(file_path, 'r') as f:
-    lines = list(f.readlines())
+def remove_builtins(*, file_path: Path) -> None:
+  lines = file_path.read_text().splitlines()
   builtins_line_index = next(
     (i for i, line in enumerate(lines) if "from builtins" in line), None
   )
   if builtins_line_index:
     lines.pop(builtins_line_index)
-    with open(file_path, 'w') as f:
-      f.writelines(lines)
+    file_path.write_text("\n".join(lines) + "\n")
 
 
-def safe_to_remove_future_from_build(file_path: str) -> bool:
-  with open(file_path, 'r') as f:
-    lines = list(f.readlines())
+def safe_to_remove_future_from_build(*, file_path: Path) -> bool:
+  lines = file_path.read_text().splitlines()
   return all(
     "from future.utils" not in line and
     "from future.moves" not in line
@@ -187,12 +68,9 @@ def safe_to_remove_future_from_build(file_path: str) -> bool:
   )
 
 
-# --------------------------------------------------
-# Update BUILD
-# -------------------------------------------------
-
-def _find_target_index_in_build(build_lines: List[str], pants_target_name: str,
-                                file_name: str) -> int:
+def _find_target_index_in_build(
+  *, build_lines: List[str], pants_target_name: str, file_name: str
+) -> int:
   index = next((i for i, line in enumerate(build_lines)
                 if f"name = '{pants_target_name}'" in line
                 or f"name='{pants_target_name}'" in line),
@@ -204,18 +82,18 @@ def _find_target_index_in_build(build_lines: List[str], pants_target_name: str,
   return index
 
 
-def update_build_dependencies(folder_root: str, pants_target_name: str, file_name: str) -> None:
-  build_file = f'{folder_root}/BUILD'
-  with open(build_file, 'r') as f:
-    lines = list(f.readlines())
-  target_index = _find_target_index_in_build(lines, pants_target_name, file_name)
+def update_build_dependencies(*, file_path: Path, pants_target_name: str) -> None:
+  build_file: Path = file_path.parent / "BUILD"
+  lines = build_file.read_text().splitlines()
+  target_index = _find_target_index_in_build(
+    build_lines=lines, pants_target_name=pants_target_name, file_name=file_path.name
+  )
   future_line_index = next(
     (i for i, line in enumerate(lines[target_index:]) if '3rdparty/python:future' in line), None
   )
   if future_line_index:
     lines.pop(future_line_index + target_index)
-    with open(build_file, 'w') as f:
-      f.writelines(lines)
+    build_file.write_text("\n".join(lines) + "\n")
 
 
 if __name__ == '__main__':

--- a/scripts/fsqio/python3-port-utils/pants/remove_builtins.py
+++ b/scripts/fsqio/python3-port-utils/pants/remove_builtins.py
@@ -135,18 +135,12 @@ REGEX = r'from builtins import'
 def check_what_needs_changes(folder_root: str, root_only: bool) -> None:
   target = f"{folder_root}/*.py" if root_only else f"{folder_root}/**/*.py"
   grep_output = get_stdout(['rg', '-l', REGEX, '-g', target]).split('\n')
-  remove_unnecessary = [p for p in grep_output
-                        if p and not already_has_builtin_open(p)]
+  remove_unnecessary = [p for p in grep_output if p]
   if not remove_unnecessary:
     print('No builtins imports 🐍 🎉')
     return
   pretty_printed = format_for_cli(remove_unnecessary, root_only)
   print(pretty_printed)
-
-
-def already_has_builtin_open(file_path: str) -> bool:
-  rg_search = get_stdout(['rg', r'from builtins import.*open.*', file_path])
-  return bool(rg_search)
 
 
 def format_for_cli(file_paths: List[str], root_only: bool) -> str:

--- a/scripts/fsqio/python3-port-utils/pants/remove_builtins.py
+++ b/scripts/fsqio/python3-port-utils/pants/remove_builtins.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+
+import argparse
+import shutil
+import subprocess
+from textwrap import dedent
+
+from typing import List, NamedTuple
+
+
+def main() -> None:
+  check_ripgrep_installed()
+  parser = create_parser()
+  args = parser.parse_args()
+  if not args.file_names:
+    target_root = determine_target_root(args.folder, args.contrib, args.test)
+    check_what_needs_changes(target_root, args.root_only)
+    return
+  for file_name in args.file_names:
+    paths = determine_paths(args, file_name)
+    remove_builtins(paths.file_path)
+    if safe_to_remove_future_from_build(paths.file_path):
+      update_build_dependencies(paths.target_root, paths.pants_target_name, file_name)
+
+
+# --------------------------------------------------
+# Command line utils
+# -------------------------------------------------
+
+def get_stdout(command: List[str]) -> str:
+  return subprocess.run(
+    command,
+    stdout=subprocess.PIPE,
+    encoding='utf-8') \
+    .stdout.strip()
+
+
+def get_stderr(command: List[str]) -> str:
+  return subprocess.run(
+    command,
+    stderr=subprocess.PIPE,
+    encoding='utf-8') \
+    .stderr.strip()
+
+
+def check_ripgrep_installed() -> None:
+  if not shutil.which('rg'):
+    raise SystemExit(
+      'Ripgrep must be installed. See https://github.com/BurntSushi/ripgrep#installation.')
+
+
+# --------------------------------------------------
+# Setup
+# -------------------------------------------------
+
+def create_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(description='Add open() backport to targets.')
+  parser.add_argument('folder', help='Target folder name, e.g. backend/jvm')
+  parser.add_argument(
+    'file_names',
+    nargs='*',
+    default=[],
+    help='Specific .py file(s). Ignore this arg to see changes necessary in folder.'
+  )
+  parser.add_argument('-t', '--test', action='store_true', help='Operate on test targets.')
+  parser.add_argument('-p', '--preview', action='store_true', help='Do not write changes.')
+  parser.add_argument('-r', '--root-only', action='store_true',
+                      help='Do not recursively search subfolders.')
+  parser.add_argument('-c', '--contrib', action='store_true',
+                      help='Operate on targets in contrib/.')
+  return parser
+
+
+class Paths(NamedTuple):
+  target_root: str
+  file_path: str
+  pants_target_name: str
+  pants_target_path: str
+  pants_test_path: str
+
+
+SRC_BASE_ROOT = 'src/python/pants'
+TEST_BASE_ROOT = 'tests/python/pants_test'
+
+
+def determine_paths(args, file_name: str) -> Paths:
+  target_root = determine_target_root(args.folder, args.contrib, args.test)
+  test_root = determine_target_root(args.folder, args.contrib, is_test=True)
+  pants_target_name = determine_pants_target_name(target_root, file_name)
+  file_path = f'{target_root}/{file_name}'
+  pants_target_path = f'{target_root}:{pants_target_name}'
+  pants_test_path = f'{test_root}:{pants_target_name}'
+  return Paths(
+    target_root=target_root,
+    file_path=file_path,
+    pants_target_name=pants_target_name,
+    pants_target_path=pants_target_path,
+    pants_test_path=pants_test_path
+  )
+
+
+def determine_target_root(folder: str, is_contrib: bool, is_test: bool) -> str:
+  if is_contrib:
+    target_folder_root = folder.split('/')[0]
+    base_root = (f'contrib/{target_folder_root}/{TEST_BASE_ROOT}/contrib'
+                 if is_test
+                 else f'contrib/{target_folder_root}/{SRC_BASE_ROOT}/contrib')
+  else:
+    base_root = TEST_BASE_ROOT if is_test else SRC_BASE_ROOT
+  return f'{base_root}/{folder}' if folder else base_root
+
+
+def determine_pants_target_name(target_root: str, file_name: str) -> str:
+  file_map = get_stdout([
+    './pants',
+    'filemap',
+    f'{target_root}:'
+  ]).split('\n')
+  target_entry = next((line for line in file_map if file_name in line), None)
+  if target_entry is None:
+    raise SystemExit(dedent(f"""\n
+        ERROR: File name '{file_name}' invalid. Not found anywhere in {target_root}/BUILD."""))
+  pants_target_path = target_entry.split(' ')[1]
+  pants_target_name = pants_target_path.split(':')[1]
+  return pants_target_name
+
+
+# --------------------------------------------------
+# Grep
+# -------------------------------------------------
+
+REGEX = r'from builtins import'
+
+
+def check_what_needs_changes(folder_root: str, root_only: bool) -> None:
+  target = f"{folder_root}/*.py" if root_only else f"{folder_root}/**/*.py"
+  grep_output = get_stdout(['rg', '-l', REGEX, '-g', target]).split('\n')
+  remove_unnecessary = [p for p in grep_output
+                        if p and not already_has_builtin_open(p)]
+  if not remove_unnecessary:
+    print('No builtins imports 🐍 🎉')
+    return
+  pretty_printed = format_for_cli(remove_unnecessary, root_only)
+  print(pretty_printed)
+
+
+def already_has_builtin_open(file_path: str) -> bool:
+  rg_search = get_stdout(['rg', r'from builtins import.*open.*', file_path])
+  return bool(rg_search)
+
+
+def format_for_cli(file_paths: List[str], root_only: bool) -> str:
+  def drop_prefix(line: str) -> str:
+    return (line.split(f'{TEST_BASE_ROOT}/')[1]
+            if TEST_BASE_ROOT in line
+            else line.split(f'{SRC_BASE_ROOT}/')[1])
+
+  remove_path_prefix = [drop_prefix(line) for line in file_paths]
+
+  if 'contrib' in file_paths[0]:
+    remove_path_prefix = [line.split('contrib/')[1] for line in remove_path_prefix]
+  formatted_for_cli = ([f"{line.split('/')[-1]}" for line in remove_path_prefix]
+                       if root_only
+                       else [f"{'/'.join(line.split('/')[:-1])} {line.split('/')[-1]}" for line in
+                             remove_path_prefix])
+  delimiter = '\n' if not root_only else ' '
+  return delimiter.join(sorted(formatted_for_cli))
+
+
+# --------------------------------------------------
+# Remove import
+# -------------------------------------------------
+
+def remove_builtins(file_path: str) -> None:
+  with open(file_path, 'r') as f:
+    lines = list(f.readlines())
+  builtins_line_index = next(
+    (i for i, line in enumerate(lines) if "from builtins" in line), None
+  )
+  if builtins_line_index:
+    lines.pop(builtins_line_index)
+    with open(file_path, 'w') as f:
+      f.writelines(lines)
+
+
+def safe_to_remove_future_from_build(file_path: str) -> bool:
+  with open(file_path, 'r') as f:
+    lines = list(f.readlines())
+  return all(
+    "from future.utils" not in line and
+    "from future.moves" not in line
+    for line in lines
+  )
+
+
+# --------------------------------------------------
+# Update BUILD
+# -------------------------------------------------
+
+def _find_target_index_in_build(build_lines: List[str], pants_target_name: str,
+                                file_name: str) -> int:
+  index = next((i for i, line in enumerate(build_lines)
+                if f"name = '{pants_target_name}'" in line
+                or f"name='{pants_target_name}'" in line),
+               None)
+  if index is None:  # mono-target
+    index = next((i for i, line in enumerate(build_lines) if file_name in line), None)
+    if index is None:  # only one target block in file, and sources aren't specified
+      index = next(i for i, line in enumerate(build_lines) if 'python_' in line and '(' in line)
+  return index
+
+
+def update_build_dependencies(folder_root: str, pants_target_name: str, file_name: str) -> None:
+  build_file = f'{folder_root}/BUILD'
+  with open(build_file, 'r') as f:
+    lines = list(f.readlines())
+  target_index = _find_target_index_in_build(lines, pants_target_name, file_name)
+  future_line_index = next(
+    (i for i, line in enumerate(lines[target_index:]) if '3rdparty/python:future' in line), None
+  )
+  if future_line_index:
+    lines.pop(future_line_index + target_index)
+    with open(build_file, 'w') as f:
+      f.writelines(lines)
+
+
+if __name__ == '__main__':
+  try:
+    main()
+  except KeyboardInterrupt:
+    pass

--- a/scripts/fsqio/python3-port-utils/pants/update_decode_encode.py
+++ b/scripts/fsqio/python3-port-utils/pants/update_decode_encode.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+from pathlib import Path
+
+from typing import Sequence, Set
+
+ENCODING_REGEX = r"""('utf-8'|"utf-8"|'UTF-8'|"UTF-8")"""
+DECODE_REGEX = rf".decode\({ENCODING_REGEX}\)"
+ENCODE_REGEX = rf".encode\({ENCODING_REGEX}\)"
+
+
+def main() -> None:
+  folders = create_parser().parse_args().folders
+  for fp in get_relevant_files(folders):
+    simplify(file_path=fp, regex=DECODE_REGEX, replacement=".decode()")
+    simplify(file_path=fp, regex=ENCODE_REGEX, replacement=r".encode()")
+
+
+def create_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(
+    description='Remove `from builtins import x`, and possibly the BUILD entry for `future`.')
+  parser.add_argument('folders', nargs='*')
+  return parser
+
+
+def get_relevant_files(folders: Sequence[str]) -> Set[Path]:
+  return {
+    fp
+    for folder in folders
+    for fp in Path(folder).rglob("*.py")
+    if any(
+      re.search(ENCODE_REGEX, line) or re.search(DECODE_REGEX, line)
+      for line in fp.read_text().splitlines()
+    )
+  }
+
+
+def simplify(*, file_path: Path, regex: str, replacement: str) -> None:
+  lines = file_path.read_text().splitlines()
+  indexes = [i for i, line in enumerate(lines) if re.search(regex, line)]
+  for index in indexes:
+    new_line = re.sub(regex, replacement, lines[index])
+    lines[index] = new_line
+  file_path.write_text("\n".join(lines) + "\n")
+
+
+if __name__ == '__main__':
+  try:
+    main()
+  except KeyboardInterrupt:
+    pass

--- a/scripts/fsqio/python3-port-utils/pants/update_headers.py
+++ b/scripts/fsqio/python3-port-utils/pants/update_headers.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import argparse
+
+from typing import List
+from glob import glob
+
+
+ENCODING_INDEX = 0
+FUTURE_IMPORT_INDEX = 4
+
+
+def main() -> None:
+  folders = create_parser().parse_args().folders
+  files = {
+    f
+    for folder in folders
+    for f in glob(f"{folder}/**/*.py", recursive=True)
+    if not f.endswith("__init__.py")
+  }
+  for file in files:
+    with open(file, "r") as f:
+      lines = list(f.readlines())
+    if is_py2_header(lines[:FUTURE_IMPORT_INDEX + 1]):
+      rewrite(file, lines)
+
+
+def create_parser() -> argparse.ArgumentParser:
+  parser = argparse.ArgumentParser(
+    description='Use the new header without __future__ imports and # encoding.')
+  parser.add_argument('folders', nargs='*')
+  return parser
+
+
+def is_py2_header(header: List[str]) -> bool:
+  return "# coding=utf-8" in header[ENCODING_INDEX] and "from __future__" in header[FUTURE_IMPORT_INDEX]
+
+
+def rewrite(path: str , lines: List[str]) -> None:
+  with open(path, "w") as f:
+    f.writelines(lines[ENCODING_INDEX + 1:FUTURE_IMPORT_INDEX] + lines[FUTURE_IMPORT_INDEX + 1:])
+
+
+if __name__ == '__main__':
+  try:
+    main()
+  except KeyboardInterrupt:
+    pass

--- a/scripts/fsqio/python3-port-utils/pants/update_headers.py
+++ b/scripts/fsqio/python3-port-utils/pants/update_headers.py
@@ -38,7 +38,9 @@ def is_py2_header(header: List[str]) -> bool:
 
 def rewrite(path: str , lines: List[str]) -> None:
   with open(path, "w") as f:
-    f.writelines(lines[ENCODING_INDEX + 1:FUTURE_IMPORT_INDEX] + lines[FUTURE_IMPORT_INDEX + 1:])
+    f.writelines(
+      lines[ENCODING_INDEX + 1:FUTURE_IMPORT_INDEX] + lines[FUTURE_IMPORT_INDEX + 2:]
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These scripts were developed to modernize https://github.com/pantsbuild/pants as it drops Python 2 and can start to use Python 3-only features.

* `remove_builtins.py` unravels part of the `future` library by removing all `from builtins` imports, which no-op in Py3. Its main innovations are the CLI interface and removing `BUILD` entries if possible.
* `update_headers.py` removes `from __future__` imports and `# coding=utf-8` lines, which both no-op on Python 3.
* `update_decode_encode.py` uses the default `utf-8` encoding to simplify string calls to `encode()` and `decode()`.
* `modernize_classes.py` simplifies calls to `super()` and removes the unnecessary `object` base class, as all classes are new style in Python 3.