### PR TITLE
Excluding hadoop-lzo from ivy resolution

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -499,6 +499,7 @@ global_excludes: [
     # NOTE: This org.apache.zookeeper#zookeeper-client is also an internal twitter thing, somehow.
     {"org": "org.apache.zookeeper", "name": "zookeeper-client"},
     {"org": "com.hadoop", "name": "hadoop-lzo"},
+    {"org": "com.twitter", "name": "hadoop-lzo"},
   ]
 
 

--- a/pants.ini
+++ b/pants.ini
@@ -498,6 +498,7 @@ global_excludes: [
     {"org": "com.twitter", "name": "zookeeper"},
     # NOTE: This org.apache.zookeeper#zookeeper-client is also an internal twitter thing, somehow.
     {"org": "org.apache.zookeeper", "name": "zookeeper-client"},
+    {"org": "com.twitter", "name": "hadoop-lzo"},
   ]
 
 

--- a/pants.ini
+++ b/pants.ini
@@ -498,7 +498,7 @@ global_excludes: [
     {"org": "com.twitter", "name": "zookeeper"},
     # NOTE: This org.apache.zookeeper#zookeeper-client is also an internal twitter thing, somehow.
     {"org": "org.apache.zookeeper", "name": "zookeeper-client"},
-    {"org": "com.hadoop", "name": "hadoop-lzo"},
+    {"org": "com.hadoop.gplcompression", "name": "hadoop-lzo"},
     {"org": "com.twitter", "name": "hadoop-lzo"},
   ]
 

--- a/pants.ini
+++ b/pants.ini
@@ -498,7 +498,7 @@ global_excludes: [
     {"org": "com.twitter", "name": "zookeeper"},
     # NOTE: This org.apache.zookeeper#zookeeper-client is also an internal twitter thing, somehow.
     {"org": "org.apache.zookeeper", "name": "zookeeper-client"},
-    {"org": "com.twitter", "name": "hadoop-lzo"},
+    {"org": "com.hadoop", "name": "hadoop-lzo"},
   ]
 
 

--- a/pants.ini
+++ b/pants.ini
@@ -498,8 +498,8 @@ global_excludes: [
     {"org": "com.twitter", "name": "zookeeper"},
     # NOTE: This org.apache.zookeeper#zookeeper-client is also an internal twitter thing, somehow.
     {"org": "org.apache.zookeeper", "name": "zookeeper-client"},
+    # Hadoop LZO compression is also provided by twitter
     {"org": "com.hadoop.gplcompression", "name": "hadoop-lzo"},
-    {"org": "com.twitter", "name": "hadoop-lzo"},
   ]
 
 

--- a/src/jvm/io/fsq/twofishes/scripts/serve.py
+++ b/src/jvm/io/fsq/twofishes/scripts/serve.py
@@ -59,7 +59,7 @@ if (len(options.hotfix) > 0):
 if options.vm_map_count:
   command_args += ['--vm_map_count', options.vm_map_count]
 
-cmd = './pants -ldebug %s src/jvm/io/fsq/twofishes/server:server-bin %s' % (
+cmd = './pants -ldebug --resolve-ivy-args=-debug %s src/jvm/io/fsq/twofishes/server:server-bin %s' % (
   goal,
   ' '.join(['--jvm-run-jvm-program-args=%s' % (a) for a in command_args])
 )

--- a/src/jvm/io/fsq/twofishes/scripts/serve.py
+++ b/src/jvm/io/fsq/twofishes/scripts/serve.py
@@ -59,7 +59,7 @@ if (len(options.hotfix) > 0):
 if options.vm_map_count:
   command_args += ['--vm_map_count', options.vm_map_count]
 
-cmd = './pants -ldebug --resolve-ivy-args=-debug %s src/jvm/io/fsq/twofishes/server:server-bin %s' % (
+cmd = './pants %s src/jvm/io/fsq/twofishes/server:server-bin %s' % (
   goal,
   ' '.join(['--jvm-run-jvm-program-args=%s' % (a) for a in command_args])
 )

--- a/src/jvm/io/fsq/twofishes/scripts/serve.py
+++ b/src/jvm/io/fsq/twofishes/scripts/serve.py
@@ -59,7 +59,7 @@ if (len(options.hotfix) > 0):
 if options.vm_map_count:
   command_args += ['--vm_map_count', options.vm_map_count]
 
-cmd = './pants %s src/jvm/io/fsq/twofishes/server:server-bin %s' % (
+cmd = './pants -ldebug %s src/jvm/io/fsq/twofishes/server:server-bin %s' % (
   goal,
   ' '.join(['--jvm-run-jvm-program-args=%s' % (a) for a in command_args])
 )


### PR DESCRIPTION
As described in issue #62, com.hadoop.gplcompression.hadoop-lzo fails to resolve in some circumstances.  It appears to be an internal twitter dependency that is not used by fsq.io.  Corrected this issue by adding a global exclusion to pants.ini.  Took several tries to get the org right. 