### PR TITLE
Update fsqio.ivysettings.xml

### DIFF
--- a/build-support/fsqio/ivy/fsqio.ivysettings.xml
+++ b/build-support/fsqio/ivy/fsqio.ivysettings.xml
@@ -22,7 +22,11 @@ Copyright 2015 Foursquare Labs Inc. All Rights Reserved.
       <ibiblio name="osgeo"
                m2compatible="true"
                usepoms="true"
-               root="http://download.osgeo.org/webdav/geotools//"/>
+               root="https://repo.osgeo.org/repository/release/"/>
+      <ibiblio name="osgeo-snapshot"
+               m2compatible="true"
+               usepoms="true"
+               root="https://repo.osgeo.org/repository/snapshot/"/>
       <ibiblio name="maven-central" m2compatible="true" descriptor="required"/>
       <!-- Maven Central. Preferred in a vacuum but the above geojson issue forces our hand. -->
       <ibiblio name="maven.twttr.com-maven"


### PR DESCRIPTION
The location to access OSGEO dependencies has moved, and Geotools are unaccessible, which is keeping twofishes from building. An announcement was published on 04/2020 at http://geotoolsnews.blogspot.com/2020/04/change-to-maven-repositories.html?m=1.  Based on my research, it seems prudent to add both the /release/ and /snapshot/ repos.