### PR TITLE
s2-geometry library

### DIFF
--- a/3rdparty/BUILD
+++ b/3rdparty/BUILD
@@ -7,7 +7,7 @@ jar_library(
     'opensource',
   ],
   jars = [
-    jar(org = 'org.jnegre.google', name = 's2-geometry', rev = '1.0')
+    jar(org = 'io.sgr', name = 's2-geometry-library-java', rev = '1.0.0')
   ]
 )
 


### PR DESCRIPTION
The s2-geometry library is no longer hosted at bintray by jnegre.  Guessing that's because JFrog runs Bintray and has deprecated it.  Another individual has made the original Google s2 geometry package available on maven central.